### PR TITLE
Factory System Implemented

### DIFF
--- a/Interactive/Engine/Engine.vcxproj
+++ b/Interactive/Engine/Engine.vcxproj
@@ -183,6 +183,7 @@
     <ClCompile Include="external\imgui\imgui_impl_opengl3.cpp" />
     <ClCompile Include="external\imgui\imgui_tables.cpp" />
     <ClCompile Include="external\imgui\imgui_widgets.cpp" />
+    <ClCompile Include="FactorySystem.cpp" />
     <ClCompile Include="GarbageCollector.cpp" />
     <ClCompile Include="input\InputManager.cpp" />
     <ClCompile Include="Interactive.cpp" />
@@ -215,6 +216,7 @@
     <ClInclude Include="external\imgui\imstb_rectpack.h" />
     <ClInclude Include="external\imgui\imstb_textedit.h" />
     <ClInclude Include="external\imgui\imstb_truetype.h" />
+    <ClInclude Include="FactorySystem.h" />
     <ClInclude Include="GarbageCollector.h" />
     <ClInclude Include="includes\Components.h" />
     <ClInclude Include="includes\CoreIncludes.h" />

--- a/Interactive/Engine/Engine.vcxproj.filters
+++ b/Interactive/Engine/Engine.vcxproj.filters
@@ -102,6 +102,9 @@
     <ClCompile Include="TestComponent2.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="FactorySystem.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="file-io\DiskReader.h">
@@ -213,6 +216,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="TestComponent2.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="FactorySystem.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/Interactive/Engine/FactorySystem.cpp
+++ b/Interactive/Engine/FactorySystem.cpp
@@ -1,0 +1,13 @@
+#include "FactorySystem.h"
+
+std::map<std::string, FactorySystem::ConstructFunction> FactorySystem::ConstructorMap;
+
+FactorySystem::FactorySystem(Interactive* engine) : Engine(engine)
+{
+	ConstructorMap.emplace("null", &NullConstructor);
+}
+
+Component* FactorySystem::NullConstructor()
+{
+	return nullptr;
+}

--- a/Interactive/Engine/FactorySystem.h
+++ b/Interactive/Engine/FactorySystem.h
@@ -1,0 +1,16 @@
+#pragma once
+#include "includes/CoreIncludes.h"
+
+class FactorySystem
+{
+public:
+	typedef Component* (*ConstructFunction)(void);
+
+	Interactive* Engine;
+	
+	static std::map<std::string, ConstructFunction> ConstructorMap;
+	FactorySystem(Interactive* engine);
+
+private:
+	static Component* NullConstructor();
+};

--- a/Interactive/Engine/Interactive.cpp
+++ b/Interactive/Engine/Interactive.cpp
@@ -1,5 +1,7 @@
 #include "includes/CoreIncludes.h"
 
+std::map<std::string, InteractiveObject*> Interactive::GlobalObjectPointers;
+
 Interactive::Interactive(std::string gameName)
 	: GameName(gameName), MainCamera(nullptr)
 {
@@ -8,11 +10,14 @@ Interactive::Interactive(std::string gameName)
 	InputSystem = new InputManager(this);
 	TextureSystem = new TextureManager(this);
 	GC = new GarbageCollector(this);
+	Factory = new FactorySystem(this);
 
 	ImGui::CreateContext();
 	ImGui_ImplGlfw_InitForOpenGL(GameWindow->GlWindow, true);
 	ImGui_ImplOpenGL3_Init("#version 150");
 	ImGui::StyleColorsDark();
+
+	GlobalObjectPointers.emplace("null", nullptr);
 }
 
 Interactive::~Interactive() {}
@@ -76,6 +81,9 @@ void Interactive::Close()
 
 	delete(GC);
 	GC = nullptr;
+
+	delete(Factory);
+	Factory = nullptr;
 
 	glfwTerminate();
 }

--- a/Interactive/Engine/Interactive.h
+++ b/Interactive/Engine/Interactive.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <map>
 #include <string>
 
 class Entity;
@@ -9,6 +10,7 @@ class Camera;
 class EntityManager;
 class Window;
 class GarbageCollector;
+class FactorySystem;
 class Interactive
 {
 public:
@@ -19,6 +21,9 @@ public:
 	InputManager* InputSystem;
 	TextureManager* TextureSystem;
 	GarbageCollector* GC;
+	FactorySystem* Factory;
+
+	static std::map<std::string, InteractiveObject*> GlobalObjectPointers;
 
 	Interactive(std::string gameName);
 	~Interactive();

--- a/Interactive/Engine/TestComponent.cpp
+++ b/Interactive/Engine/TestComponent.cpp
@@ -11,6 +11,18 @@ void TestComponent::Initialize()
 	Component::Initialize();
 
 	InputController->BindKeyboardCallback(this);
+
+	FactorySystem* factory = GetEnginePtr()->Factory;
+
+	// If not already registered, register the factory constructor to the map
+	if (factory->ConstructorMap.find("SpriteDefault") == factory->ConstructorMap.end())
+	{
+		factory->ConstructorMap["SpriteDefault"] = &FactoryConstructor;
+		std::cout << "Cosntructing" << std::endl;
+	}
+
+	// TODO: Change this after LUA implementation
+	Interactive::GlobalObjectPointers["TestEntity"] = Owner;
 }
 
 void TestComponent::BeginPlay()
@@ -50,6 +62,11 @@ void TestComponent::KeyboardCallback()
 	{
 		GetTransform()->SetSize(glm::vec2(100.0f, 100.0f));
 	}
+
+	if(InputController->GetKeyState(Keys::F1) == KeyActions::PRESS)
+	{
+		GetEnginePtr()->Factory->ConstructorMap["SpriteDefault"]();
+	}
 }
 
 void TestComponent::OnMarkedForDestruction()
@@ -57,4 +74,10 @@ void TestComponent::OnMarkedForDestruction()
 	Component::OnMarkedForDestruction();
 
 	InputController->UnbindKeyboardCallback(this);
+}
+
+Component* TestComponent::FactoryConstructor()
+{
+	Entity* entity = dynamic_cast<Entity*>(Interactive::GlobalObjectPointers["TestEntity"]);
+	return entity->AddComponent<TestComponent2>();
 }

--- a/Interactive/Engine/TestComponent.h
+++ b/Interactive/Engine/TestComponent.h
@@ -15,4 +15,7 @@ public:
 
 protected:
 	void OnMarkedForDestruction() override;
+
+private:
+	static Component* FactoryConstructor();
 };

--- a/Interactive/Engine/components/Sprite2D.cpp
+++ b/Interactive/Engine/components/Sprite2D.cpp
@@ -120,6 +120,10 @@ void Sprite2D::AttachTexture(Texture* textureToAttach)
 	Shader->LinkProgram();
 }
 
+void Sprite2D::BeginPlay()
+{
+}
+
 void Sprite2D::OnMarkedForDestruction()
 {
 	Component::OnMarkedForDestruction();

--- a/Interactive/Engine/components/Sprite2D.h
+++ b/Interactive/Engine/components/Sprite2D.h
@@ -11,7 +11,7 @@ class VertexArray;
 class Sprite2D : public Component
 {
 public:
-	glm::vec4 Color;
+	glm::vec4 Color{};
 	ShaderProgram* Shader;
 
 	Sprite2D(glm::vec3 position, glm::vec2 size, glm::vec4 color);
@@ -26,6 +26,9 @@ public:
 
 	VertexArray* GetVAO() const { return VAO; }
 
+
+	void BeginPlay() override;
+
 protected:
 	VertexArray* VAO;
 
@@ -33,7 +36,7 @@ protected:
 
 private:
 	friend class Transform;
-	
+
 	Texture* AttachedTexture;
 
 	void CreateSprite2D();

--- a/Interactive/Engine/imgui.ini
+++ b/Interactive/Engine/imgui.ini
@@ -14,7 +14,7 @@ Size=123,98
 Collapsed=0
 
 [Window][hello]
-Pos=251,168
-Size=180,91
+Pos=274,88
+Size=392,284
 Collapsed=0
 

--- a/Interactive/Engine/includes/CoreIncludes.h
+++ b/Interactive/Engine/includes/CoreIncludes.h
@@ -8,6 +8,7 @@
 #include "../includes/Components.h"
 #include "../InteractiveObject.h"
 #include "../GarbageCollector.h"
+#include "../FactorySystem.h"
 #include "../external/imgui/imgui.h"
 #include "../external/imgui/imgui_impl_glfw.h"
 #include "../external/imgui/imgui_impl_opengl3.h"

--- a/Interactive/Engine/main.cpp
+++ b/Interactive/Engine/main.cpp
@@ -15,9 +15,6 @@ int main()
 	testEntity->AddComponent<Sprite2D>();
 	testEntity->AddComponent<TestComponent>();
 
-	Entity* testEntity2 = engine->ECManager->CreateEntity("Test Entity 2");
-	testEntity2->AddComponent<TestComponent2>();
-
 	engine->Start();
 
 	delete(engine);


### PR DESCRIPTION
Factory System utilizes static constructors that are associated with specific ids. 
Due to the constructors being static, to have an access to the engine's OOP datas I've implemented a static map for InteractiveObjects.
Since all entities and components are InteractiveObjects, we can use this map to store pointers to any InteractiveObject derived class which than the static factory constructors can utilize.